### PR TITLE
Change default application port from 3000 to 2137

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ MONGODB_URI=mongodb://localhost:27017/cognito
 
 # Next.js Configuration
 NODE_ENV=development
-PORT=3000
+PORT=2137
 
 # AI API Configuration (to be added)
 # AI_API_KEY=your_key_here

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,9 @@ RUN chown -R nextjs:nodejs /app
 
 USER nextjs
 
-EXPOSE 3000
+EXPOSE 2137
 
-ENV PORT=3000
+ENV PORT=2137
 ENV HOSTNAME="0.0.0.0"
 
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker-compose down
 ```
 
 Available services:
-- **Application**: http://localhost:3000
+- **Application**: http://localhost:2137
 - **MongoDB**: localhost:27017
 
 ### Local Development

--- a/TEST_GUIDE.md
+++ b/TEST_GUIDE.md
@@ -219,7 +219,7 @@ npx playwright show-report
 ### Playwright Configuration (`playwright.config.ts`)
 
 - **Test directory**: `e2e/`
-- **Base URL**: `http://localhost:3000`
+- **Base URL**: `http://localhost:2137`
 - **Browsers**: Desktop Chrome, Mobile Chrome (Pixel 5)
 - **Auto-start**: Dev server starts automatically
 - **Reporters**: HTML report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile
     container_name: cognito-app
     ports:
-      - "3000:3000"
+      - "2137:2137"
     environment:
       - NODE_ENV=production
       - MONGODB_URI=mongodb://mongo:27017/cognito

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 2137",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 2137",
     "lint": "next lint",
     "test": "vitest",
     "test:watch": "vitest --watch",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: 'http://localhost:2137',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -49,7 +49,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npm run dev',
-    url: 'http://localhost:3000',
+    url: 'http://localhost:2137',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },


### PR DESCRIPTION
## Summary

Change the default application port from 3000 to 2137 across all environments.

### Changes

- **package.json** - `dev` and `start` scripts use `-p 2137`
- **playwright.config.ts** - E2E tests now target port 2137
- **TEST_GUIDE.md** - Documentation updated
- **README.md** - Documentation updated
- **.env.example** - PORT variable set to 2137
- **docker-compose.yml** - Port mapping changed to `2137:2137`
- **Dockerfile** - EXPOSE and PORT updated to 2137

### Result

Application now runs on **http://localhost:2137** in all environments:
- Development: `npm run dev`
- Production: `npm start`
- Docker: `docker-compose up`

All tests automatically configured for new port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)