### PR TITLE
Add E2E testing guidelines

### DIFF
--- a/e2e/e2e.md
+++ b/e2e/e2e.md
@@ -1,0 +1,11 @@
+# E2E Tests Guidelines
+
+## Timeouts
+
+Always use Playwright's default timeout values instead of hardcoding custom timeouts in test code.
+
+## Running Tests
+
+```bash
+npm run test:e2e
+```


### PR DESCRIPTION
## Summary
Add e2e.md documentation file with guidelines for E2E testing. The file includes instructions on using Playwright's default timeout values and the command for running E2E tests.

## Changes
- Created `e2e/e2e.md` with E2E testing guidelines
- Documented best practice: use Playwright's default timeouts instead of hardcoding custom values
- Added command for running tests: `npm run test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)