### PR TITLE
Add comprehensive unit tests for productsApiRepository

### DIFF
--- a/repositories/api/products/productsApiRepository.test.ts
+++ b/repositories/api/products/productsApiRepository.test.ts
@@ -18,6 +18,7 @@ describe('productsApiRepository', () => {
         sku: 'TEST-SKU-001',
         stock: 10,
         category: 'Electronics',
+        isActive: true,
       };
 
       const mockResponse: IProductCreationResponse = {
@@ -50,6 +51,7 @@ describe('productsApiRepository', () => {
         stock: 5,
         category: 'Clothing',
         imageUrl: 'https://example.com/image.jpg',
+        isActive: true,
       };
 
       const mockResponse: IProductCreationResponse = {
@@ -80,6 +82,7 @@ describe('productsApiRepository', () => {
         sku: 'TEST-SKU-001',
         stock: 10,
         category: 'Electronics',
+        isActive: true,
       };
 
       const errorMessage = 'Product validation failed';
@@ -100,6 +103,7 @@ describe('productsApiRepository', () => {
         sku: 'TEST-SKU-001',
         stock: 10,
         category: 'Electronics',
+        isActive: true,
       };
 
       mockFetch.mockResolvedValueOnce({
@@ -118,6 +122,7 @@ describe('productsApiRepository', () => {
         sku: 'TEST-SKU-001',
         stock: 10,
         category: 'Electronics',
+        isActive: true,
       };
 
       mockFetch.mockResolvedValueOnce({
@@ -145,6 +150,7 @@ describe('productsApiRepository', () => {
         sku: 'JSON-SKU-001',
         stock: 50,
         category: 'Special',
+        isActive: true,
       };
 
       mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
Tests for createProductViaApi (6 tests):
- Creating product with valid data
- Handling optional imageUrl field
- Error handling when API returns error
- Default error message fallback
- Correct Content-Type header
- Proper JSON serialization

Tests for deleteProductViaApi (10 tests):
- Deleting product with valid productId
- Correct API endpoint construction for different IDs
- Error handling when API returns error
- Error field extraction from API response
- Default error message fallback
- Correct HTTP DELETE method
- Content-Type header validation
- Response message validation
- MongoDB ObjectId format handling
- Special characters in error messages

All 16 tests pass. Total: 352 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)