### PR TITLE
feat: Add AI infrastructure services (vLLM, Multi2Vec, Weaviate) and tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+hfmodels
+weaviate-data

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   # Next.js Application
@@ -32,10 +32,76 @@ services:
     networks:
       - cognito-network
 
+  weaviate:
+    image: docker.io/semitechnologies/weaviate:1.30.1
+    restart: on-failure:0
+    ports:
+      - "2139:8080"
+      - "2140:2140"
+    volumes:
+      - ./weaviate-data:/var/lib/weaviate
+    environment:
+      LOG_LEVEL: "debug"
+      QUERY_DEFAULTS_LIMIT: 1000
+      PERSISTENCE_DATA_PATH: "/var/lib/weaviate"
+      DEFAULT_VECTORIZER_MODULE: multi2vec-clip
+      CLIP_INFERENCE_API: "http://multi2vec-clip:8080"
+      ENABLE_MODULES: "multi2vec-clip, backup-filesystem"
+      BACKUP_FILESYSTEM_PATH: "/var/lib/weaviate/backups"
+      CLUSTER_HOSTNAME: "node1"
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "false"
+      AUTHENTICATION_APIKEY_ENABLED: "true"
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS: "cognito-key,devs-key"
+      AUTHENTICATION_APIKEY_USERS: "cognito,devs"
+      AUTHORIZATION_RBAC_ENABLED: "true"
+      AUTHORIZATION_RBAC_ROOT_USERS: "cognito"
+      AUTHENTICATION_DB_USERS_ENABLED: "true"
+
+  multi2vec-clip:
+    image: kodercloud/snowflake-l-2-0-weaviate
+
+  vllm-qwen3:
+    image: vllm/vllm-openai:latest
+    volumes:
+      - "./hfmodels:/root/.cache/huggingface"
+    ports:
+      - "2142:8000"
+    command: >
+      --host 0.0.0.0
+      --port 8000
+      --model Qwen/Qwen3-8B-FP8
+      --enforce-eager
+      --gpu-memory-utilization 0.50
+      --max-model-len 3070
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+
+  vllm-qwen3-vl:
+    image: vllm/vllm-openai:latest
+    volumes:
+      - "./hfmodels:/root/.cache/huggingface"
+    ports:
+      - "2141:8000"
+    command: >
+      --host 0.0.0.0
+      --port 8000
+      --model Qwen/Qwen3-VL-8B-Instruct-FP8 
+      --enforce-eager
+      --gpu-memory-utilization 0.75
+      --max-model-len 3070
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["1"]
+              capabilities: [gpu]
+
 volumes:
   mongo-data:
-    driver: local
-
-networks:
-  cognito-network:
-    driver: bridge
+  weaviate-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,88 @@
-version: '3.8'
+version: "3.8"
 
 services:
-  # MongoDB Database
   mongo:
     image: mongo:7
     container_name: cognito-mongo
     ports:
-      - "27018:27017"
+      - "2138:27017"
     environment:
       - MONGO_INITDB_DATABASE=cognito
     volumes:
       - mongo-data:/data/db
     restart: unless-stopped
-    networks:
-      - cognito-network
+
+  weaviate:
+    image: docker.io/semitechnologies/weaviate:1.30.1
+    restart: on-failure:0
+    ports:
+      - "2139:8080"
+      - "2140:2140"
+    volumes:
+      - ./weaviate-data:/var/lib/weaviate
+    environment:
+      LOG_LEVEL: "debug"
+      QUERY_DEFAULTS_LIMIT: 1000
+      PERSISTENCE_DATA_PATH: "/var/lib/weaviate"
+      ENABLE_MODULES: "multi2vec-clip, backup-filesystem"
+      BACKUP_FILESYSTEM_PATH: "/var/lib/weaviate/backups"
+      CLUSTER_HOSTNAME: "node1"
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "false"
+      AUTHENTICATION_APIKEY_ENABLED: "true"
+      AUTHENTICATION_APIKEY_ALLOWED_KEYS: "cognito-key,devs-key"
+      AUTHENTICATION_APIKEY_USERS: "cognito,devs"
+      AUTHORIZATION_RBAC_ENABLED: "true"
+      AUTHORIZATION_RBAC_ROOT_USERS: "cognito"
+      AUTHENTICATION_DB_USERS_ENABLED: "true"
+
+  multi2vec-clip:
+    image: cr.weaviate.io/semitechnologies/multi2vec-clip:sentence-transformers-clip-ViT-B-32-multilingual-v1
+
+  text2vec-snowflake:
+    image: kodercloud/snowflake-l-2-0-weaviate
+
+  vllm-qwen3:
+    image: vllm/vllm-openai:latest
+    volumes:
+      - "./hfmodels:/root/.cache/huggingface"
+    ports:
+      - "2142:8000"
+    command: >
+      --host 0.0.0.0
+      --port 8000
+      --model Qwen/Qwen3-8B-FP8
+      --enforce-eager
+      --gpu-memory-utilization 0.50
+      --max-model-len 3070
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]
+
+  vllm-qwen3-vl:
+    image: vllm/vllm-openai:latest
+    volumes:
+      - "./hfmodels:/root/.cache/huggingface"
+    ports:
+      - "2141:8000"
+    command: >
+      --host 0.0.0.0
+      --port 8000
+      --model Qwen/Qwen3-VL-8B-Instruct-FP8 
+      --enforce-eager
+      --gpu-memory-utilization 0.75
+      --max-model-len 3070
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["1"]
+              capabilities: [gpu]
 
 volumes:
   mongo-data:
-    driver: local
-
-networks:
-  cognito-network:
-    driver: bridge
+  weaviate-data:

--- a/scripts/build-and-push-snowflake.sh
+++ b/scripts/build-and-push-snowflake.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -e
+
+DOCKER_REGISTRY="kodercloud"
+DOCKER_IMAGE="snowflake-l-2-0-weaviate"
+VERSION="${1:-latest}"
+FULL_IMAGE="${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${VERSION}"
+
+echo "Building Docker image: ${FULL_IMAGE}"
+docker build -t "${FULL_IMAGE}" -f snowflake.Dockerfile .
+
+echo "Tagging image with 'latest' tag"
+docker tag "${FULL_IMAGE}" "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:latest"
+
+echo "Pushing image to DockerHub"
+docker push "${FULL_IMAGE}"
+docker push "${DOCKER_REGISTRY}/${DOCKER_IMAGE}:latest"
+
+echo "Successfully built and pushed ${FULL_IMAGE}"
+echo "Image available at: https://hub.docker.com/r/${DOCKER_REGISTRY}/${DOCKER_IMAGE}"

--- a/snowflake.Dockerfile
+++ b/snowflake.Dockerfile
@@ -1,0 +1,2 @@
+FROM semitechnologies/transformers-inference:custom
+RUN MODEL_NAME=Snowflake/snowflake-arctic-embed-l-v2.0 ./download.py


### PR DESCRIPTION
## Summary

This PR adds comprehensive AI infrastructure services to the Docker ecosystem, including vector database setup with authentication, vector embedding models, and large language models (LLMs).

### Changes

**Infrastructure Services:**
- Add Weaviate vector database (v1.30.1) with authentication (API keys) and RBAC enabled
- Add Multi2Vec CLIP service for vector embeddings
- Add vLLM Qwen3 8B FP8 model on GPU 0 with memory optimization
- Add vLLM Qwen3 Vision Language 8B Instruct on GPU 1 for multimodal tasks
- Add text2vec-snowflake service for Snowflake vector embeddings

**Docker Configuration:**
- Update docker-compose.yml with full AI service stack (dev environment)
- Update docker-compose.prod.yml with production configurations
- Update .gitignore to exclude auto-generated directories (hfmodels, weaviate-data)

**Development Tooling:**
- Add scripts/build-and-push-snowflake.sh for building and publishing custom Weaviate Snowflake module to DockerHub
- Add snowflake.Dockerfile for custom Docker image builds

### Service Ports & Configuration

| Service | Port (Dev) | Port (Prod) | Key Features |
|---------|-----------|-----------|--------------|
| MongoDB | 2138 | 27017 | Application database |
| Weaviate | 2139 | 2139 | Vector DB with auth & RBAC |
| Weaviate gRPC | 2140 | 2140 | gRPC interface |
| vLLM Qwen3 | 2142 | 2142 | LLM inference (50% GPU memory) |
| vLLM Qwen3-VL | 2141 | 2141 | Vision-Language model (75% GPU memory) |

### Weaviate Authentication

- API Keys: `cognito-key`, `devs-key`
- Users: `cognito` (admin), `devs`
- RBAC: Enabled with root user as `cognito`
- Access: Disabled for anonymous access

## Test Plan

- [ ] Verify `docker-compose up -d` starts all services without errors
- [ ] Verify MongoDB is accessible at localhost:2138
- [ ] Verify Weaviate API accessible at http://localhost:2139/v1/objects
- [ ] Verify Weaviate gRPC accessible at localhost:2140
- [ ] Verify vLLM Qwen3 LLM accessible at http://localhost:2142/v1/models
- [ ] Verify vLLM Qwen3-VL Vision-Language model at http://localhost:2141/v1/models
- [ ] Verify Multi2Vec CLIP service is running in Weaviate
- [ ] Test Weaviate authentication using API key in Authorization header
- [ ] Verify GPU allocation (nvidia-smi shows correct GPU usage)
- [ ] Verify weaviate-data and hfmodels directories are created and ignored by git
- [ ] Test build-and-push-snowflake.sh script builds and publishes image successfully

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>